### PR TITLE
Simplify Attendance and Punctuality

### DIFF
--- a/policies/attendance-and-punctuality.md
+++ b/policies/attendance-and-punctuality.md
@@ -2,29 +2,22 @@
 
 Attendance and punctuality are important factors for your success within our company. We work as a team and this requires that each person be in the right place at the right time.
 
-If you are going to be late for work or absent, notify management as far in advance as is feasible under the circumstances, but before the start of your workday.
+If you are going to be late for work or absent, notify the operations team by emailing <admin@thoughtbot.com>, and the rest of your team, as far in advance as is feasible under the circumstances.
 
-Personal issues requiring time away from your work, such as doctor’s appointments or other matters, should be scheduled during your nonworking hours if possible.
+Personal issues requiring time away from work should be scheduled during your nonworking hours, if possible.
 
 ## Business Hours
 
-Because of the nature of our business, your work schedule may vary depending on your job. Our normal business hours are 9:00 a.m. to 5:00 p.m., Monday through Friday.
+Our normal business hours are 9:00 a.m. to 5:00 p.m., Monday through Friday.
 
+## Working Hours
 
-## Flextime
+You may set your own working hours, as long as your obligations to the company and clients are met. Communicate with your team about what your schedule will be, and once you have establish a regular working schedule, let the rest of your team know if you'll be deviating from it.
 
-Our company offers a flextime plan to all employees. This plan allows you to set your own working hours, within certain constraints.
-
-Under this plan, you are required to work seven hours plus take a one-hour paid meal break each day. Everyone must be here during core hours which are 10:00 a.m. to 4:00 p.m. but may "flex" the remainder of the day starting as early as 8:00 a.m. and ending as late as 6:00 p.m.
-
-Once you have establish a working schedule, it should not be changed without letting the rest of the team know.
-
-## Meal Time
-
-Up to one hour of paid lunch break is provided for all employees working at least 7 hours each day.
+You are expected to attend your office's daily stand-up meeting.
 
 ## Contact with the Company
 
-The company should know your location at all times during business hours. Management should be notified of your whereabouts outside the company during working hours.
+The operations team should know your location at all times during business hours, and should be notified of your whereabouts outside the company during working hours.
 
 If you are absent for three days without notifying the company, it is assumed that you have voluntarily abandoned your position with the company, and you will be removed from the payroll. Under such circumstances, we will terminate your health insurance as of your last working day.


### PR DESCRIPTION
The existing written policy of "flextime" is uncessarily strict. We want
people to attend standup and to otherwise keep a pretty regular schedule,
communication with the operations team and their team about their schedule.

These changes hopewfully reflect that.